### PR TITLE
Aggregate all summable stats, expose in new JSON menu item

### DIFF
--- a/ossap_stats/ossap_stats.info
+++ b/ossap_stats/ossap_stats.info
@@ -1,9 +1,9 @@
 name = "OSSAP Stats"
 description = "Statistics for OpenScholar Single Access Point (OSSAP)"
 core = 7.x
+dependencies[] = os_stats
 
 ; Information added by drush on 2013-12-04
 version = "unknown"
 project = "ossap"
 datestamp = "1386192707"
-

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -150,8 +150,10 @@ function ossap_stats_block_worker($stat = '') {
  * Invokes drupal_http_request on each child server to get total sites stats.
  */
 function ossap_stats_sites_cron_worker() {
-  $stats = array();
+  $aggregates = array();
 
+  $stat_keys = array_keys(_os_stats_queries());
+  $unsummable = array('filesize');
   $servers = variable_get('ossap_child_domains', array());
   $domains = array_keys($servers);
   $options = array();
@@ -160,18 +162,21 @@ function ossap_stats_sites_cron_worker() {
     $result = drupal_http_request($url, $options);
     if (isset($result->data)) {
       $data = drupal_json_decode($result->data);
-	    foreach (variable_get('os_stats_enabled',array('websites')) as $stat){
+	    foreach ($stat_keys as $stat) {
+        if (in_array($stat, $unsummable)) {
+          continue;
+        }
 		    if (isset($data[$stat]['value'])) {
-		      if(!isset($stats[$stat])){
-		        $stats[$stat] = 0;
+		      if(!isset($aggregates[$stat])){
+            $aggregates[$stat] = 0;
 		      }
-	        $stats[$stat] += $data[$stat]['value'];
+          $aggregates[$stat] += $data[$stat]['value'];
 	      }
 			}
     }
   }
 
-  if ($count) {
-    variable_set('ossap_stats_stats', $stats);
+  if (count($aggregates)) {
+    variable_set('ossap_stats_stats', $aggregates);
   }
 }

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -16,6 +16,14 @@ define('OSSAP_SITES_BLOCK_SETTINGS', 'ossap_stats_sites_settings');
 function ossap_stats_menu() {
   $items = array();
 
+  $items['ossap/stats'] = array(
+    'title' => t('OpenScholar SAP stats'),
+    'page callback' => '_ossap_stats_page',
+    'page arguments' => array(2),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
   $items['ossap/stats/%/code'] = array(
     'title' => t('OpenScholar Stats'),
     'page callback' => '_ossap_stats_code',

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -56,6 +56,19 @@ function ossap_stats_theme() {
 }
 
 /**
+ * Page callback; exposes all OSSAP stats in one JSON object.
+ */
+function _ossap_stats_page() {
+  $data = array(
+    'success' => TRUE,
+    'child_domains' => variable_get('ossap_child_domains', array()),
+    'aggregates' => variable_get('ossap_stats_stats', array()),
+  );
+  
+  drupal_json_output($data);
+}
+
+/**
  * Page callback; formats and displays the embed code to paste on any site.
  */
 function _ossap_stats_code($stat) {


### PR DESCRIPTION
#8
#### Changes
- New menu item `"ossap/stats"` similar to `"stats"` but exposes OSSAP domains and totals
- Update ossap_stats_cron_worker to sum all summable stats, not just "websites"
