### PR TITLE
Unify OSSAP stats embed JS #8

### DIFF
--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -3,19 +3,53 @@
 /**
  * @file
  * Javascript source to print the total sites onto the page.
+ *
+ * Available variables:
+ *
+ * $aggregates - the value of the 'ossap_stats_aggregates' variable, an indexed
+ * array where keys are the statistic's description, and values are numeric
+ * values.
  */
 
-if(empty($stats)){
-  $stats = array();
-}
+global $base_url;
+$src = "$base_url/ossap/stats.js";
 ?>
-
-
-/** Updates the div element to contain the latest total number of vsites. */
-function ossapStatsGet(stat) {
+/**
+ * Include this JS file to embed aggregated OpenScholar SAP stats on any page.
+ * Like this:
+ * @code
+ * <script type="text/javascript" src="<?php echo $src; ?>"></script>
+ * @endcode
+ *
 <?php
-foreach (variable_get('os_stats_enabled',array('websites')) as $stat){
-  echo "if (stat == '{$stat}') {\nreturn '{$stats[$stat]}'; ?>';\n}\n";
+if (empty($aggregates)) {
+  echo " * Something is wrong. Either no child domains are configured, or the\n";
+  echo " * ossap_stats cron job needs to be run. Contact a system administrator.\n";
+  echo " */";
+  die();
 }
 ?>
-}
+ * Your HTML markup may use any of the following id attributes to get numbers:
+ * @code
+<? foreach ($aggregates as $key => $value): ?>
+ * <div id="ossap-stats-<?php echo $key; ?>"></div>
+<? endforeach; ?>
+ * @endcode
+ *
+ * Note: The examples above use DIV tags, but you may use SPAN, P, etc.
+ *
+ * @see https://github.com/openscholar/ossap
+ */
+(function(){
+
+<? foreach ($aggregates as $key => $value): ?>
+  // Total <?php echo $key; ?>
+
+  var elem = document.getElementById('ossap-stats-<?php echo $key; ?>');
+  if (typeof div !== 'undefined' && div !== null) {
+    <?php $value = ($key == 'filesize_bytes') ? format_size($value) : $value ?>
+    div.innerText = '<?php echo $value; ?>';
+  }
+
+<? endforeach; ?>
+})();

--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -46,9 +46,9 @@ if (empty($aggregates)) {
   // Total <?php echo $key; ?>
 
   var elem = document.getElementById('ossap-stats-<?php echo $key; ?>');
-  if (typeof div !== 'undefined' && div !== null) {
+  if (typeof elem !== 'undefined' && elem !== null) {
     <?php $value = ($key == 'filesize_bytes') ? format_size($value) : $value ?>
-    div.innerText = '<?php echo $value; ?>';
+    elem.innerText = '<?php echo $value; ?>';
   }
 
 <? endforeach; ?>

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -24,15 +24,7 @@ function ossap_stats_menu() {
     'type' => MENU_CALLBACK,
   );
 
-  $items['ossap/stats/%/code'] = array(
-    'title' => t('OpenScholar Stats'),
-    'page callback' => '_ossap_stats_code',
-    'page arguments' => array(2),
-    'access callback' => TRUE,
-    'type' => MENU_CALLBACK,
-  );
-
-  $items['ossap/stats/%/embed.js'] = array(
+  $items['ossap/stats.js'] = array(
     'title' => t('OpenScholar Stats'),
     'page callback' => '_ossap_stats_embed_js',
     'page arguments' => array(2),
@@ -64,48 +56,18 @@ function _ossap_stats_page() {
     'child_domains' => variable_get('ossap_child_domains', array()),
     'aggregates' => variable_get('ossap_stats_aggregates', array()),
   );
-  
+
   drupal_json_output($data);
 }
 
 /**
  * Page callback; formats and displays the embed code to paste on any site.
  */
-function _ossap_stats_code($stat) {
-  // Formats the div tag whose innerText will be updated.
-  $id = "ossap-stats-$stat";
-  $div =  '<div id="' . $id . '"></div>';
-
-  // Formats the script tag which will find the value and update the div.
-  global $base_url;
-  $script_path = "/ossap/stats/$stat/embed.js";
-  $src = $base_url . $script_path;
-  $script = '<script type="text/javascript" src="' . $src . '"></script>';
-
-  // Appends the div tag and the script tag, prints to the page and exits.
-  $code = $div . $script;
-  print check_plain($code);
-  exit;
-}
-
-
-/**
- * Page callback; formats and displays the embed code to paste on any site.
- */
 function _ossap_stats_embed_js($stat) {
-  switch ($stat) {
-    case 'sites':
-      // Fetches the latest total sites variable value.
-      $stats = variable_get('ossap_stats_stats', array());
-      // Inserts commas like "1,000".
-      foreach ($stats as $key => $number){
-        $stats[$key] = number_format($number);
-      }
-
-      drupal_add_http_header('Content-Type', 'text/javascript; charset=utf-8');
-      print theme('ossap_stats_embed_js', array('stats' => $stats));
-      exit;
-  }
+  drupal_add_http_header('Content-Type', 'text/javascript; charset=utf-8');
+  $aggregates = variable_get('ossap_stats_aggregates', array());
+  print theme('ossap_stats_embed_js', array('aggregates' => $aggregates));
+  exit;
 }
 
 /**

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -62,7 +62,7 @@ function _ossap_stats_page() {
   $data = array(
     'success' => TRUE,
     'child_domains' => variable_get('ossap_child_domains', array()),
-    'aggregates' => variable_get('ossap_stats_stats', array()),
+    'aggregates' => variable_get('ossap_stats_aggregates', array()),
   );
   
   drupal_json_output($data);
@@ -177,6 +177,6 @@ function ossap_stats_sites_cron_worker() {
   }
 
   if (count($aggregates)) {
-    variable_set('ossap_stats_stats', $aggregates);
+    variable_set('ossap_stats_aggregates', $aggregates);
   }
 }


### PR DESCRIPTION
#8
#### Changes
- New single JS file `"ossap/stats.js"` provides all avaliable stats and embed code snippets
- No more individual stat-specific embed codes
- No more separate code snippet menu item.
#### When there are no stats, this message appears:

![screen shot 2014-01-08 at 4 19 44 pm](https://f.cloud.github.com/assets/228733/1872929/94da4fe4-78ae-11e3-95e3-99ced2bed1e5.png)
#### Normal output:

![screen shot 2014-01-08 at 4 20 04 pm](https://f.cloud.github.com/assets/228733/1872928/8eccc5dc-78ae-11e3-9b63-dc910a5e1da2.png)
