### PR TITLE
Add current OS release version to embed JS and JSON callback #8

### DIFF
--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -12,6 +12,11 @@
  */
 
 $src = url('ossap/stats.js', array('absolute' => TRUE));
+
+if (isset($os_version)) {
+  $aggregates['os_version'] = $os_version;
+}
+
 ?>
 /**
  * Include this JS file to embed aggregated OpenScholar SAP stats on any page.
@@ -39,10 +44,11 @@ if (empty($aggregates)) {
  *
  * @see https://github.com/openscholar/ossap
  */
+
 (function(){
 
 <? foreach ($aggregates as $key => $value): ?>
-  // Total <?php echo $key; ?>
+  // Current <?php echo $key; ?>
 
   var elem = document.getElementById('ossap-stats-<?php echo $key; ?>');
   if (typeof elem !== 'undefined' && elem !== null) {

--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -11,8 +11,7 @@
  * values.
  */
 
-global $base_url;
-$src = "$base_url/ossap/stats.js";
+$src = url('ossap/stats.js', array('absolute' => TRUE));
 ?>
 /**
  * Include this JS file to embed aggregated OpenScholar SAP stats on any page.

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -51,16 +51,20 @@ function ossap_stats_theme() {
  * Page callback; exposes all OSSAP stats in one JSON object.
  */
 function _ossap_stats_page() {
+  // Prepares a safe version of the child_domains variable to expose.
   $child_domains = variable_get('ossap_child_domains', array());
   foreach ($child_domains as $url => $info) {
     if (isset($info['restuser'])) {
       unset($child_domains[$url]['restuser']);
     }
   }
+
+  // Prepares the data array to render to the page as JSON.
   $data = array(
     'success' => TRUE,
     'child_domains' => $child_domains,
     'aggregates' => variable_get('ossap_stats_aggregates', array()),
+    'os_version' => _ossap_stats_get_os_version(),
   );
 
   drupal_json_output($data);
@@ -72,7 +76,12 @@ function _ossap_stats_page() {
 function _ossap_stats_embed_js($stat) {
   drupal_add_http_header('Content-Type', 'text/javascript; charset=utf-8');
   $aggregates = variable_get('ossap_stats_aggregates', array());
-  print theme('ossap_stats_embed_js', array('aggregates' => $aggregates));
+  $variables = array(
+    'aggregates' => $aggregates,
+    'os_version' => _ossap_stats_get_os_version(),
+  );
+
+  print theme('ossap_stats_embed_js', $variables);
   exit;
 }
 
@@ -147,4 +156,18 @@ function ossap_stats_sites_cron_worker() {
   if (count($aggregates)) {
     variable_set('ossap_stats_aggregates', $aggregates);
   }
+}
+
+/**
+ * Gets current OpenScholar release version string, like "3.10".
+ */
+function _ossap_stats_get_os_version() {
+  // Parses the info file to get os_version.
+  $path = drupal_get_path('profile', 'openscholar') . '/openscholar.info';
+  $info = drupal_parse_info_file($path);
+
+  // Removes the Drupal major version number prefix (i.e. "7.x-").
+  $os_version = substr($info['os_version'], 4);
+
+  return $os_version;
 }

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -163,8 +163,7 @@ function ossap_stats_sites_cron_worker() {
  */
 function _ossap_stats_get_os_version() {
   // Parses the info file to get os_version.
-  $path = drupal_get_path('profile', 'openscholar') . '/openscholar.info';
-  $info = drupal_parse_info_file($path);
+  $info = system_get_info('module','openscholar');
 
   // Removes the Drupal major version number prefix (i.e. "7.x-").
   $os_version = substr($info['os_version'], 4);


### PR DESCRIPTION
#8

See also https://github.com/openscholar/openscholar/issues/4901
#### Changes
- New private getter func `_ossap_get_os_version()` returns a string like `"3.10"`
- Added this new dynamic value as a statistic in both embed JS and `/ossap/stats`
