### PR TITLE
Add GetSatisfaction to JSON, Activity to embed JS #8

### DIFF
--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -12,6 +12,11 @@
  */
 
 $src = url('ossap/stats.js', array('absolute' => TRUE));
+
+if (isset($os_version)) {
+  $aggregates['os_version'] = $os_version;
+}
+
 ?>
 /**
  * Include this JS file to embed aggregated OpenScholar SAP stats on any page.
@@ -39,10 +44,11 @@ if (empty($aggregates)) {
  *
  * @see https://github.com/openscholar/ossap
  */
+
 (function(){
 
 <? foreach ($aggregates as $key => $value): ?>
-  // Total <?php echo $key; ?>
+  // Current <?php echo $key; ?>
 
   var elem = document.getElementById('ossap-stats-<?php echo $key; ?>');
   if (typeof elem !== 'undefined' && elem !== null) {

--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -11,8 +11,7 @@
  * values.
  */
 
-global $base_url;
-$src = "$base_url/ossap/stats.js";
+$src = url('ossap/stats.js', array('absolute' => TRUE));
 ?>
 /**
  * Include this JS file to embed aggregated OpenScholar SAP stats on any page.

--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -16,7 +16,9 @@ $src = url('ossap/stats.js', array('absolute' => TRUE));
 if (isset($os_version)) {
   $aggregates['os_version'] = $os_version;
 }
-
+if (isset($messages) && !empty($messages)) {
+  $aggregates['activity-messages'] = $messages;
+}
 ?>
 /**
  * Include this JS file to embed aggregated OpenScholar SAP stats on any page.
@@ -53,8 +55,8 @@ if (empty($aggregates)) {
   var elem = document.getElementById('ossap-stats-<?php echo $key; ?>');
   if (typeof elem !== 'undefined' && elem !== null) {
     <?php $value = ($key == 'filesize_bytes') ? format_size($value) : $value ?>
-    elem.innerText = '<?php echo $value; ?>';
     <?php $value = (is_numeric($value)) ? number_format($value) : $value ?>
+    elem.innerHTML = '<?php echo $value; ?>';
   }
 
 <? endforeach; ?>

--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -54,6 +54,7 @@ if (empty($aggregates)) {
   if (typeof elem !== 'undefined' && elem !== null) {
     <?php $value = ($key == 'filesize_bytes') ? format_size($value) : $value ?>
     elem.innerText = '<?php echo $value; ?>';
+    <?php $value = (is_numeric($value)) ? number_format($value) : $value ?>
   }
 
 <? endforeach; ?>

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -51,16 +51,20 @@ function ossap_stats_theme() {
  * Page callback; exposes all OSSAP stats in one JSON object.
  */
 function _ossap_stats_page() {
+  // Prepares a safe version of the child_domains variable to expose.
   $child_domains = variable_get('ossap_child_domains', array());
   foreach ($child_domains as $url => $info) {
     if (isset($info['restuser'])) {
       unset($child_domains[$url]['restuser']);
     }
   }
+
+  // Prepares the data array to render to the page as JSON.
   $data = array(
     'success' => TRUE,
     'child_domains' => $child_domains,
     'aggregates' => variable_get('ossap_stats_aggregates', array()),
+    'os_version' => _ossap_stats_get_os_version(),
   );
 
   drupal_json_output($data);
@@ -72,7 +76,12 @@ function _ossap_stats_page() {
 function _ossap_stats_embed_js($stat) {
   drupal_add_http_header('Content-Type', 'text/javascript; charset=utf-8');
   $aggregates = variable_get('ossap_stats_aggregates', array());
-  print theme('ossap_stats_embed_js', array('aggregates' => $aggregates));
+  $variables = array(
+    'aggregates' => $aggregates,
+    'os_version' => _ossap_stats_get_os_version(),
+  );
+
+  print theme('ossap_stats_embed_js', $variables);
   exit;
 }
 
@@ -147,4 +156,18 @@ function ossap_stats_sites_cron_worker() {
   if (count($aggregates)) {
     variable_set('ossap_stats_aggregates', $aggregates);
   }
+}
+
+/**
+ * Gets current OpenScholar release version string, like "3.10".
+ */
+function _ossap_stats_get_os_version() {
+  // Parses the info file to get os_version.
+  $path = drupal_get_path('profile', 'openscholar') . '/openscholar.info';
+  $info = drupal_parse_info_file($path);
+
+  // Removes the Drupal major version number prefix (i.e. "7.x-").
+  $os_version = substr($info['os_version'], 4);
+
+  return $os_version;
 }

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -73,6 +73,12 @@ function _ossap_stats_page() {
     $data['getsatisfaction'] = $getsatisfaction;
   }
 
+  // Adds activity statistics if any statistics exist.
+  $activity = variable_get('ossap_stats_activity', NULL);
+  if ($activity !== NULL) {
+    $data['activity'] = $activity;
+  }
+
   drupal_json_output($data);
 }
 

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -9,7 +9,7 @@
  * Defines the settings variable name for the total child sites count block.
  */
 define('OSSAP_SITES_BLOCK_SETTINGS', 'ossap_stats_sites_settings');
-
+define('OSSAP_STATS_EMBED_MESSAGE_COUNT_DEFAULT', 3);
 /**
  * Implements hook_menu().
  */

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -88,9 +88,24 @@ function _ossap_stats_page() {
 function _ossap_stats_embed_js($stat) {
   drupal_add_http_header('Content-Type', 'text/javascript; charset=utf-8');
   $aggregates = variable_get('ossap_stats_aggregates', array());
+
+  // Prepares the activity messages.
+  $messages = '';
+  $activity = variable_get('ossap_stats_activity');
+  if (isset($activity['messages']) && !empty($activity['messages'])) {
+    $count = variable_get('ossap_stats_embed_message_count', OSSAP_STATS_EMBED_MESSAGE_COUNT_DEFAULT);
+    $items = array_slice($activity['messages'], 0, $count);
+    $build = array(
+      '#theme' => 'item_list',
+      '#items' => $items,
+      '#attributes' => array('class' => array('ossap-stats-embed-messages')),
+    );
+    $messages = drupal_render($build);
+  }
   $variables = array(
     'aggregates' => $aggregates,
     'os_version' => _ossap_stats_get_os_version(),
+    'messages' => $messages,
   );
 
   print theme('ossap_stats_embed_js', $variables);

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -67,6 +67,12 @@ function _ossap_stats_page() {
     'os_version' => _ossap_stats_get_os_version(),
   );
 
+  // Adds GetSatisfaction statistics if any statistics exist.
+  $getsatisfaction = variable_get('ossap_stats_getsatisfaction', NULL);
+  if ($getsatisfaction !== NULL) {
+    $data['getsatisfaction'] = $getsatisfaction;
+  }
+
   drupal_json_output($data);
 }
 
@@ -104,7 +110,7 @@ function ossap_stats_cron_queue_info() {
 function ossap_stats_cron() {
   $queue = DrupalQueue::get('ossap_stats_queue');
   $queue->createQueue();
-  $stats = array('sites');
+  $stats = array('sites', 'getsatisfaction');
   foreach ($stats as $stat) {
     $queue->createItem($stat);
   }
@@ -118,6 +124,21 @@ function ossap_stats_block_worker($stat = '') {
     case 'sites':
       ossap_stats_sites_cron_worker();
       break;
+    case 'getsatisfaction':
+      ossap_stats_getsatisfaction_cron_worker();
+      break;
+  }
+}
+
+function ossap_stats_getsatisfaction_cron_worker() {
+  $function = 'getsatisfaction_integration_stats';
+  if (!function_exists($function)) {
+    return;
+  }
+
+  $getsatisfaction_stats = $function();
+  if (!empty($getsatisfaction_stats)) {
+    variable_set('ossap_stats_getsatisfaction', $getsatisfaction_stats);
   }
 }
 

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -227,3 +227,30 @@ function _ossap_stats_get_os_version() {
 
   return $os_version;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter() for os_settings_form.
+ *
+ * Allows admins to set the global Google Analytics ID and sitewide options.
+ */
+function ossap_stats_form_os_settings_form_alter(&$form, &$form_state, $form_id) {
+  $form['ossap_stats'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('OSSAP Stats'),
+    '#weight' => 1,
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $prefix = '<h4>' . t('Embeddable stats') . '</h4><p class="description">';
+  $prefix .= t('These settings affect the information available in the <a href="!href">OSSAP Stats embed JS</a>.', array('!href' => url('ossap/stats.js'))) . '</p>';
+  $form['ossap_stats']['ossap_stats_embed_message_count'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Activity message count'),
+    '#prefix' => $prefix,
+    '#weight' => 15,
+    '#size' => 6,
+    '#maxlength' => 255,
+    '#default_value' => variable_get('ossap_stats_embed_message_count', OSSAP_STATS_EMBED_MESSAGE_COUNT_DEFAULT),
+    '#description' => t('(Integer) How many recent activity messages to display.'),
+  );
+}

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -110,7 +110,7 @@ function ossap_stats_cron_queue_info() {
 function ossap_stats_cron() {
   $queue = DrupalQueue::get('ossap_stats_queue');
   $queue->createQueue();
-  $stats = array('sites', 'getsatisfaction');
+  $stats = array('sites', 'getsatisfaction', 'activity');
   foreach ($stats as $stat) {
     $queue->createItem($stat);
   }
@@ -127,6 +127,9 @@ function ossap_stats_block_worker($stat = '') {
     case 'getsatisfaction':
       ossap_stats_getsatisfaction_cron_worker();
       break;
+    case 'activity':
+      ossap_stats_activity_cron_worker();
+      break;
   }
 }
 
@@ -139,6 +142,38 @@ function ossap_stats_getsatisfaction_cron_worker() {
   $getsatisfaction_stats = $function();
   if (!empty($getsatisfaction_stats)) {
     variable_set('ossap_stats_getsatisfaction', $getsatisfaction_stats);
+  }
+}
+
+/**
+ * Cron queue worker to aggregate latest status messages.
+ */
+function ossap_stats_activity_cron_worker() {
+  $activity = array();
+
+  $servers = variable_get('ossap_child_domains', array());
+  $domains = array_keys($servers);
+  $options = array();
+  foreach ($domains as $domain) {
+    $url = "http://$domain/activity.json";
+    $result = drupal_http_request($url, $options);
+    if (isset($result->data)) {
+      $data = drupal_json_decode($result->data);
+      foreach ($data['messages'] as $key => $info) {
+        $activity['messages'][$key] = array(
+          'data' => $info['markup'],
+        );
+      }
+    }
+  }
+
+  if (!empty($activity)) {
+    if (!empty($activity['messages'])) {
+      // Sorts the activity messages first by timestamp desc, then by nid desc.
+      ksort($activity['messages'], SORT_NUMERIC);
+      $activity['messages'] = array_reverse($activity['messages']);
+    }
+    variable_set('ossap_stats_activity', $activity);
   }
 }
 


### PR DESCRIPTION
#8
#### Changes
- Adds GetSatisfaction stats to ossap stats JSON (needs testing in prod to see results)
- Add aggregated messages (10 per site) to ossap stats JSON
- Adds aggregated messages (custom size, unordered list) to embed JS
#### Screenshots
##### The new aggregated messages data

![screen shot 2014-01-15 at 11 58 45 am](https://f.cloud.github.com/assets/228733/1922411/54b88af4-7e06-11e3-906b-52e6014d3550.png)
##### The new OSSAP stats openscholar settings

![screen shot 2014-01-15 at 11 43 36 am](https://f.cloud.github.com/assets/228733/1922402/3648ac2a-7e06-11e3-854c-d242638374c1.png)
