### PR TITLE
Fix truncated version number, prepend activities with "time ago" #8

### DIFF
--- a/ossap_stats/ossap-stats-embed-js.tpl.php
+++ b/ossap_stats/ossap-stats-embed-js.tpl.php
@@ -55,7 +55,7 @@ if (empty($aggregates)) {
   var elements = document.getElementsByClassName('ossap-stats-<?php echo $key; ?>');
   for(var i = 0; i < elements.length; i++) {
     <?php $value = ($key == 'filesize_bytes') ? format_size($value) : $value ?>
-    <?php $value = (is_numeric($value)) ? number_format($value) : $value ?>
+    <?php $value = ($key != "os_version" && is_numeric($value)) ? number_format($value) : $value ?>
     <?php $value = ($key == 'activity-messages') ? $value : "'{$value}'" ?>
     elements[i].innerHTML = <?php echo $value; ?>;
   }

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -279,6 +279,8 @@ function ossap_stats_form_os_settings_form_alter(&$form, &$form_state, $form_id)
 
 /**
  * Returns an HTML5 semantic time tag with datetime, title and time ago text.
+ *
+ * @see http://microformats.org/wiki/abbr-datetime-pattern
  */
 function _ossap_stats_time_markup($timestamp) {
   $markup = '';

--- a/ossap_stats/ossap_stats.module
+++ b/ossap_stats/ossap_stats.module
@@ -181,8 +181,10 @@ function ossap_stats_activity_cron_worker() {
     if (isset($result->data)) {
       $data = drupal_json_decode($result->data);
       foreach ($data['messages'] as $key => $info) {
+        $time = _ossap_stats_time_markup($info['timestamp']);
+
         $activity['messages'][$key] = array(
-          'data' => $info['markup'],
+          'data' => $time . $info['markup'],
         );
       }
     }
@@ -273,4 +275,33 @@ function ossap_stats_form_os_settings_form_alter(&$form, &$form_state, $form_id)
     '#default_value' => variable_get('ossap_stats_embed_message_count', OSSAP_STATS_EMBED_MESSAGE_COUNT_DEFAULT),
     '#description' => t('(Integer) How many recent activity messages to display.'),
   );
+}
+
+/**
+ * Returns an HTML5 semantic time tag with datetime, title and time ago text.
+ */
+function _ossap_stats_time_markup($timestamp) {
+  $markup = '';
+
+  if (!empty($timestamp) && is_numeric($timestamp)) {
+    $time = format_interval(time() - $timestamp);
+    $datetime = strftime('%Y-%m-%d %H:%M:%S%z', $timestamp);
+    $title = format_date($timestamp);
+    $time_ago = t('@time ago', array('@time' => $time));
+    $build = array(
+      '#theme' => 'html_tag',
+      '#tag' => 'time',
+      '#attributes' => array(
+        'class' => array(
+          'time',
+        ),
+        'datetime' => $datetime,
+        'title' => $title,
+      ),
+      '#value' => $time_ago,
+    );
+    $markup = drupal_render($build);
+  }
+
+  return $markup;
 }


### PR DESCRIPTION
#8
#### Changes
- Prevent number format from stripping os version number
- Format a "time ago" prefix for aggregated activity messages
